### PR TITLE
Hide Theme Debug overlay outside dev mode

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -368,7 +368,8 @@ export default function DashboardPage() {
           onSelectTodo={handleSelectTodo}
         />
       </main>
-      <ThemeDebug />
+      {(process.env.NODE_ENV === 'development' ||
+        process.env.NEXT_PUBLIC_THEME_DEBUG === 'true') && <ThemeDebug />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- hide the ThemeDebug overlay unless in development or explicitly enabled by `NEXT_PUBLIC_THEME_DEBUG`

## Testing
- `npm test` *(fails: `playwright` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688129a8e70c832d9ac80ca26f331389