### PR TITLE
Fix text color contrast in secondary elements

### DIFF
--- a/components/features/dashboard/DashboardHeader.tsx
+++ b/components/features/dashboard/DashboardHeader.tsx
@@ -34,7 +34,7 @@ export function DashboardHeader({ stats, isOnline, userEmail, onLogout }: Dashbo
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <span className="text-sm hidden md:inline font-medium bg-muted/30 px-3 py-1 rounded text-secondary">
+          <span className="text-sm hidden md:inline font-medium bg-muted/30 px-3 py-1 rounded text-secondary-foreground">
             {userEmail}
           </span>
           <ThemeToggle />

--- a/components/features/todo/TodoItem.tsx
+++ b/components/features/todo/TodoItem.tsx
@@ -300,7 +300,7 @@ export function TodoItem({
                     className={`text-base mt-2 break-words leading-relaxed font-normal ${
                       todo.completed
                         ? 'text-tertiary line-through'
-                        : 'text-secondary'
+                        : 'text-secondary-foreground'
                     }`}
                   >
                     {todo.description}
@@ -308,7 +308,7 @@ export function TodoItem({
                 )}
                 {todo.type === 'shopping_list' && todo.shopping_items && (
                   <div className="mt-4 space-y-3 bg-muted/10 p-4 rounded-lg shadow-inset">
-                    <div className="text-sm font-semibold mb-3 text-secondary">Shopping items:</div>
+                    <div className="text-sm font-semibold mb-3 text-secondary-foreground">Shopping items:</div>
                     {todo.shopping_items.map((item) => (
                       <div key={item.id} className="flex items-center gap-4 p-2 rounded hover:bg-accent/50 transition-colors">
                         <Checkbox

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -16,7 +16,7 @@ const buttonVariants = cva(
         outline:
           "bg-muted/30 hover:bg-accent hover:text-accent-foreground transition-all duration-200",
         secondary:
-          "bg-muted/20 text-secondary-text hover:bg-accent/50 transition-all duration-200",
+          "bg-muted/20 text-secondary-foreground hover:bg-accent/50 transition-all duration-200",
         ghost:
           "hover:bg-accent/70 hover:text-accent-foreground transition-all duration-150",
         link: "text-primary underline-offset-4 hover:underline hover:text-primary/80 transition-colors duration-150",


### PR DESCRIPTION
## Summary
- update secondary text colors to use foreground color
- fix secondary button variant styling

## Testing
- `npm run lint`
- `npx playwright test tests/auth.spec.ts --grep "validation" --workers=1` *(fails: browser binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_68812d793800832d8c8c5c8c98dd19d7