### PR TITLE
docs: fix credential reference in tests

### DIFF
--- a/tests/todos.spec.ts
+++ b/tests/todos.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from '@playwright/test'
 
 // Mock authentication helper using demo credentials
 async function mockLogin(page: Page) {
-  // Use the demo credentials from CLAUDE.md
+  // Use the hardcoded demo credentials from README.md
   await page.goto('/login')
   await page.getByLabel('Email').fill('demo@todoapp.com')
   await page.getByLabel('Password').fill('demo123')


### PR DESCRIPTION
## Summary
- update todos test comment to point at README credentials

## Testing
- `npx playwright install --with-deps`
- `npm test` *(fails: home page accessible, login accessible, register accessible, dashboard accessible, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688cbf29017c832da6eb536eed816289