### PR TITLE
docs: translate Spanish text to English

### DIFF
--- a/__tests__/components/features/todo/AddTodo.test.tsx
+++ b/__tests__/components/features/todo/AddTodo.test.tsx
@@ -87,7 +87,7 @@ describe('AddTodo', () => {
     const user = userEvent.setup()
     validateWithSchema.mockReturnValue({
       success: false,
-      errors: ['El título es requerido', 'La descripción es muy larga']
+      errors: ['Title is required', 'Description is too long']
     })
 
     render(<AddTodo onAdd={mockOnAdd} />)
@@ -99,7 +99,7 @@ describe('AddTodo', () => {
     await user.click(submitButton)
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('⚠️ Por favor corrige los errores en el formulario', { duration: 4000 })
+      expect(toast.error).toHaveBeenCalledWith('⚠️ Please correct the errors in the form', { duration: 4000 })
     })
 
     expect(mockOnAdd).not.toHaveBeenCalled()
@@ -192,7 +192,7 @@ describe('AddTodo', () => {
     const user = userEvent.setup()
     validateWithSchema.mockReturnValueOnce({
       success: false,
-      errors: ['El título es requerido']
+      errors: ['Title is required']
     }).mockReturnValue({
       success: true,
       data: { title: 'Valid Title', description: '' }

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -149,18 +149,18 @@ function DashboardPageInternal() {
             <CardHeader className="text-center">
               <CardTitle className="text-destructive flex items-center justify-center gap-3 text-2xl">
                 <span className="text-4xl">⚠️</span>
-                Algo salió mal
+                Something went wrong
               </CardTitle>
             </CardHeader>
             <CardContent className="text-center space-y-4">
               <p className="text-xl text-muted-foreground leading-relaxed">
-                {error instanceof Error ? error.message : 'No se pudieron cargar tus tareas'}
+                {error instanceof Error ? error.message : 'Could not load your tasks'}
               </p>
               <Button 
                 onClick={() => window.location.reload()} 
                 className="w-full h-16 text-xl font-bold bg-primary hover:bg-primary/80 active:bg-primary/70 text-primary-foreground shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98]"
               >
-                🔄 Intentar de nuevo
+                🔄 Try again
               </Button>
             </CardContent>
           </Card>

--- a/components/features/todo/AddTodo.tsx
+++ b/components/features/todo/AddTodo.tsx
@@ -43,11 +43,11 @@ function AddTodoInternal({ onAdd, isCreating }: AddTodoProps) {
     if (!validation.success) {
       const errors: Partial<Record<keyof CreateTodoFormData, string>> = {}
       validation.errors.forEach(error => {
-        if (error.includes('título')) errors.title = error
-        if (error.includes('descripción')) errors.description = error
+        if (error.toLowerCase().includes('title')) errors.title = error
+        if (error.toLowerCase().includes('description')) errors.description = error
       })
       setFieldErrors(errors)
-      toast.error('⚠️ Por favor corrige los errores en el formulario', { duration: 4000 })
+      toast.error('⚠️ Please correct the errors in the form', { duration: 4000 })
       return
     }
 

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -20,14 +20,14 @@ interface AuthContextType {
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
-// Usuario demo predefinido
+// Predefined demo user
 const DEMO_USER: User = {
   id: 'demo-user-001',
   email: 'demo@todoapp.com',
-  name: 'Usuario Demo'
+  name: 'Demo User'
 }
 
-// Credenciales demo
+// Demo credentials
 const DEMO_CREDENTIALS = {
   email: 'demo@todoapp.com',
   password: 'demo123'
@@ -39,7 +39,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isSigningOut, setIsSigningOut] = useState(false)
 
   useEffect(() => {
-    // Simular carga inicial y verificar si hay sesión guardada
+    // Simulate initial load and check for saved session
     const checkSession = () => {
       const savedUser = safeLocalStorage.getItem<User>('demo-user')
       if (savedUser) {
@@ -56,23 +56,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signIn = async (email: string, password: string) => {
     setLoading(true)
     
-    // Simular un pequeño delay para la UX
+    // Simulate a small delay for better UX
     await new Promise(resolve => setTimeout(resolve, 800))
     
-    // Verificar credenciales demo
+    // Verify demo credentials
     if (email === DEMO_CREDENTIALS.email && password === DEMO_CREDENTIALS.password) {
       setUser(DEMO_USER)
       safeLocalStorage.setItem('demo-user', DEMO_USER)
       setLoading(false)
     } else {
       setLoading(false)
-      throw new Error('Credenciales inválidas. Usa: demo@todoapp.com / demo123')
+      throw new Error('Invalid credentials. Use: demo@todoapp.com / demo123')
     }
   }
 
   const signUp = async (email: string, password: string) => {
-    // Para el registro, simplemente dirigir al usuario a usar las credenciales demo
-    throw new Error('Para este demo, usa las credenciales: demo@todoapp.com / demo123')
+    // For sign up, simply direct the user to use the demo credentials
+    throw new Error('For this demo, use the credentials: demo@todoapp.com / demo123')
   }
 
   const signOut = async () => {
@@ -83,7 +83,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     
     setUser(null)
     safeLocalStorage.removeItem('demo-user')
-    // También limpiar cualquier data de todos
+    // Also clear any todo data
     safeLocalStorage.removeItem('demo-todos')
     
     setIsSigningOut(false)
@@ -104,7 +104,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 export function useAuth() {
   const context = useContext(AuthContext)
   if (context === undefined) {
-    throw new Error('useAuth debe ser usado dentro de un AuthProvider')
+    throw new Error('useAuth must be used within an AuthProvider')
   }
   return context
 }

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -4,14 +4,14 @@ import { z } from 'zod'
 export const loginSchema = z.object({
   email: z
     .string()
-    .min(1, 'El email es requerido')
-    .email('Formato de email inválido')
-    .max(100, 'El email es demasiado largo'),
+    .min(1, 'Email is required')
+    .email('Invalid email format')
+    .max(100, 'Email is too long'),
   password: z
     .string()
-    .min(1, 'La contraseña es requerida')
-    .min(6, 'La contraseña debe tener al menos 6 caracteres')
-    .max(50, 'La contraseña es demasiado larga'),
+    .min(1, 'Password is required')
+    .min(6, 'Password must be at least 6 characters')
+    .max(50, 'Password is too long'),
 })
 
 export type LoginFormData = z.infer<typeof loginSchema>
@@ -20,12 +20,12 @@ export type LoginFormData = z.infer<typeof loginSchema>
 export const createTodoSchema = z.object({
   title: z
     .string()
-    .min(1, 'El título es requerido')
-    .max(100, 'El título no puede exceder 100 caracteres')
+    .min(1, 'Title is required')
+    .max(100, 'Title cannot exceed 100 characters')
     .trim(),
   description: z
     .string()
-    .max(500, 'La descripción no puede exceder 500 caracteres')
+    .max(500, 'Description cannot exceed 500 characters')
     .trim()
     .optional()
     .or(z.literal('')),
@@ -34,12 +34,12 @@ export const createTodoSchema = z.object({
 export const updateTodoSchema = z.object({
   title: z
     .string()
-    .min(1, 'El título es requerido')
-    .max(100, 'El título no puede exceder 100 caracteres')
+    .min(1, 'Title is required')
+    .max(100, 'Title cannot exceed 100 characters')
     .trim(),
   description: z
     .string()
-    .max(500, 'La descripción no puede exceder 500 caracteres')
+    .max(500, 'Description cannot exceed 500 characters')
     .trim()
     .optional()
     .or(z.literal('')),
@@ -52,7 +52,7 @@ export type UpdateTodoFormData = z.infer<typeof updateTodoSchema>
 export const searchSchema = z.object({
   query: z
     .string()
-    .max(100, 'La búsqueda es demasiado larga')
+    .max(100, 'Search query is too long')
     .trim(),
 })
 
@@ -73,7 +73,7 @@ export function validateWithSchema<T>(
   } catch {
     return { 
       success: false, 
-      errors: ['Error de validación inesperado'] 
+      errors: ['Unexpected validation error']
     }
   }
 }

--- a/tests/performance.spec.ts
+++ b/tests/performance.spec.ts
@@ -16,14 +16,14 @@ test.describe('Performance Tests - Action Response Times', () => {
     await page.click('button:has-text("Add New Task")')
     
     // Wait for form to appear
-    await page.waitForSelector('input[placeholder*="título"]')
+    await page.waitForSelector('input[placeholder*="e.g."]')
     const formAppearTime = Date.now() - startTime
     
     expect(formAppearTime).toBeLessThan(200)
     console.log(`Add task button response time: ${formAppearTime}ms`)
     
     // Fill form and submit
-    await page.fill('input[placeholder*="título"]', 'Performance Test Task')
+    await page.fill('input[placeholder*="e.g."]', 'Performance Test Task')
     
     const submitStartTime = Date.now()
     await page.click('button:has-text("Create Task")')
@@ -39,7 +39,7 @@ test.describe('Performance Tests - Action Response Times', () => {
   test('Toggle task completion should complete under 200ms', async ({ page }) => {
     // First create a task
     await page.click('button:has-text("Add New Task")')
-    await page.fill('input[placeholder*="título"]', 'Toggle Test Task')
+    await page.fill('input[placeholder*="e.g."]', 'Toggle Test Task')
     await page.click('button:has-text("Create Task")')
     await page.waitForSelector('text=Toggle Test Task')
     
@@ -60,7 +60,7 @@ test.describe('Performance Tests - Action Response Times', () => {
   test('Delete task action should complete under 200ms', async ({ page }) => {
     // First create a task
     await page.click('button:has-text("Add New Task")')
-    await page.fill('input[placeholder*="título"]', 'Delete Test Task')
+    await page.fill('input[placeholder*="e.g."]', 'Delete Test Task')
     await page.click('button:has-text("Create Task")')
     await page.waitForSelector('text=Delete Test Task')
     
@@ -85,7 +85,7 @@ test.describe('Performance Tests - Action Response Times', () => {
   test('Edit task action should complete under 200ms', async ({ page }) => {
     // First create a task
     await page.click('button:has-text("Add New Task")')
-    await page.fill('input[placeholder*="título"]', 'Edit Test Task')
+    await page.fill('input[placeholder*="e.g."]', 'Edit Test Task')
     await page.click('button:has-text("Create Task")')
     await page.waitForSelector('text=Edit Test Task')
     
@@ -122,7 +122,7 @@ test.describe('Performance Tests - Action Response Times', () => {
     
     for (const task of tasks) {
       await page.click('button:has-text("Add New Task")')
-      await page.fill('input[placeholder*="título"]', task)
+      await page.fill('input[placeholder*="e.g."]', task)
       await page.click('button:has-text("Create Task")')
       await page.waitForSelector(`text=${task}`)
     }


### PR DESCRIPTION
## Summary
- translate Spanish comments and messages in AuthContext, validations, AddTodo, Dashboard page
- update tests to match English messages
- update performance tests to English placeholders

## Testing
- `npm test` *(fails: playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cbf23fd94832da0eacfe4d13da081